### PR TITLE
Add network selection and backend network list

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -2,15 +2,19 @@
 // Handles network data, simulation parameters, and user interactions
 
 import React, { useState, useEffect, useRef } from 'react';
-import { 
-  Container, 
-  Paper, 
+import {
+  Container,
+  Paper,
   Typography,
   CircularProgress,
   Button,
   Box,
   Grid,
-  TextField
+  TextField,
+  FormControl,
+  InputLabel,
+  Select,
+  MenuItem
 } from '@mui/material';
 import * as XLSX from 'xlsx';
 import PS_graph from './PS_graph';
@@ -18,7 +22,7 @@ import ResultsSection from './ResultsSection';
 import ParameterControls from './ParameterControls';
 
 // Control panel component for simulation actions and parameter management
-const ButtonPanel = ({ 
+const ButtonPanel = ({
   saveParameters,
   handleStartSimulation,
   downloadExcel,
@@ -28,9 +32,24 @@ const ButtonPanel = ({
   selectionMode,
   setSelectionMode,
   selectedComponent,
-  monitoredComponents
+  monitoredComponents,
+  availableNetworks,
+  selectedNetwork,
+  setSelectedNetwork
 }) => (
   <Box sx={{ display: 'flex', gap: 2, mb: 4, flexWrap: 'wrap', justifyContent: 'center' }}>
+    <FormControl sx={{ minWidth: 160 }}>
+      <InputLabel>Network</InputLabel>
+      <Select
+        value={selectedNetwork}
+        label="Network"
+        onChange={(e) => setSelectedNetwork(e.target.value)}
+      >
+        {availableNetworks.map((net) => (
+          <MenuItem key={net} value={net}>{net}</MenuItem>
+        ))}
+      </Select>
+    </FormControl>
     <Button
       variant="contained"
       color="secondary"
@@ -268,6 +287,8 @@ function App() {
   const [graphWidth, setGraphWidth] = useState(window.innerWidth * 0.8);
   const [simulationStartTime, setSimulationStartTime] = useState(null);
   const [simulationDuration, setSimulationDuration] = useState(null);
+  const [availableNetworks, setAvailableNetworks] = useState([]);
+  const [selectedNetwork, setSelectedNetwork] = useState('k2a');
   const [parameters, setParameters] = useState({
     step1: { time: 1.0, load_index: 0, g_setp: 0, b_setp: 0 },
     step2: { time: 2.0, load_index: 0, g_setp: 0, b_setp: 0 },
@@ -293,6 +314,24 @@ function App() {
     },
     t_end: 20
   });
+
+  useEffect(() => {
+    const fetchNetworks = async () => {
+      try {
+        const res = await fetch(`${API_BASE_URL}/networks`);
+        const data = await res.json();
+        if (res.ok && Array.isArray(data.networks)) {
+          setAvailableNetworks(data.networks);
+          if (!data.networks.includes(selectedNetwork)) {
+            setSelectedNetwork(data.networks[0] || '');
+          }
+        }
+      } catch (err) {
+        console.error('Failed to fetch networks', err);
+      }
+    };
+    fetchNetworks();
+  }, [selectedNetwork]);
   const [tEndInput, setTEndInput] = useState('');
   const [busPower, setBusPower] = useState(null);
   const [selectionMode, setSelectionMode] = useState(false);
@@ -373,6 +412,7 @@ function App() {
     const t_end_to_save = tEndInput === '' ? 20 : tEndInput;
     setParameters(prev => {
       const updated = { ...prev, t_end: t_end_to_save };
+      const updatedWithNetwork = { ...updated, network: selectedNetwork };
       setTimeout(async () => {
         try {
           setError(null);
@@ -381,7 +421,7 @@ function App() {
             headers: {
               'Content-Type': 'application/json',
             },
-            body: JSON.stringify(updated)
+            body: JSON.stringify(updatedWithNetwork)
           });
           if (!response.ok) {
             throw new Error('Failed to save parameters');
@@ -632,7 +672,7 @@ function App() {
       const response = await fetch(`${API_BASE_URL}/start_simulation`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(parameters)
+        body: JSON.stringify({ ...parameters, network: selectedNetwork })
       });
 
       const data = await response.json();
@@ -898,6 +938,9 @@ function App() {
             setSelectionMode={setSelectionMode}
             selectedComponent={selectedComponent}
             monitoredComponents={monitoredComponents}
+            availableNetworks={availableNetworks}
+            selectedNetwork={selectedNetwork}
+            setSelectedNetwork={setSelectedNetwork}
           />
           <TextField
             label=""


### PR DESCRIPTION
## Summary
- add backend endpoint to list available TOPS networks and include default network parameter
- dynamically load selected network in simulation thread
- introduce React dropdown and state to choose network and forward it to backend

## Testing
- `python -m py_compile backend/app.py`
- `cd frontend && npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68a1e5df0c5c832b93983afdfd3618f0